### PR TITLE
fix(landing): add viewport meta for mobile rendering

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Seojae · Terminal</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
Without the viewport tag, mobile browsers rendered the page at desktop width and the @media (max-width: 900px) responsive rules never engaged.