### PR TITLE
docs: connected-wikis 샘플 위키(Laeyoung/den) 퀵스타트

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -107,17 +107,19 @@ gemini          # Gemini CLI
 ## CLI 레퍼런스
 
 `tools/search.py`는 LLM 도구 없이 독립적으로 사용할 수 있는 유일한 컴포넌트입니다.
-Python venv가 활성화된 상태에서 실행해야 합니다.
+먼저 venv를 활성화하세요 (또는 매 명령에 `venv/bin/python` 프리픽스 사용):
 
 ```bash
+source venv/bin/activate
+
 # 시맨틱 검색
-venv/bin/python tools/search.py --query "attention mechanism" --top 5
+python tools/search.py --query "attention mechanism" --top 5
 
 # 인덱스에 페이지 추가/업데이트
-venv/bin/python tools/search.py --add wiki/concepts/attention-mechanism.md
+python tools/search.py --add wiki/concepts/attention-mechanism.md
 
 # 전체 인덱스 재구성
-venv/bin/python tools/search.py --reindex
+python tools/search.py --reindex
 ```
 
 | 인자 | 기본값 | 설명 |
@@ -160,8 +162,9 @@ venv/bin/python tools/search.py --reindex
   ([사용 가이드](docs/connected-wikis-guide.ko.md)). 공개 샘플 위키
   [`Laeyoung/den`](https://github.com/Laeyoung/den)으로 바로 테스트할 수 있습니다:
   ```bash
-  venv/bin/python tools/connected_wikis.py connect https://github.com/Laeyoung/den --id den --decision consent=accept
-  venv/bin/python tools/search.py --query "에스프레소 추출" --collections wiki,wiki-ext-den
+  source venv/bin/activate
+  python tools/connected_wikis.py connect https://github.com/Laeyoung/den --id den --decision consent=accept
+  python tools/search.py --query "에스프레소 추출" --collections wiki,wiki-ext-den
   ```
 
 직접 만들고 싶다면 [extensions/README.md](extensions/README.md)를 참고하세요.

--- a/README.ko.md
+++ b/README.ko.md
@@ -157,7 +157,12 @@ venv/bin/python tools/search.py --reindex
 - `search-chromadb.md` — 시맨틱 검색 백엔드 (ChromaDB + sentence-transformers)
 - `obsidian.md` — Obsidian vault 연동
 - `connected-wikis.md` — 외부 seojae wiki를 토글 가능한 확장 지식 저장소로 연결
-  ([사용 가이드](docs/connected-wikis-guide.ko.md))
+  ([사용 가이드](docs/connected-wikis-guide.ko.md)). 공개 샘플 위키
+  [`Laeyoung/den`](https://github.com/Laeyoung/den)으로 바로 테스트할 수 있습니다:
+  ```bash
+  venv/bin/python tools/connected_wikis.py connect https://github.com/Laeyoung/den --id den --decision consent=accept
+  venv/bin/python tools/search.py --query "에스프레소 추출" --collections wiki,wiki-ext-den
+  ```
 
 직접 만들고 싶다면 [extensions/README.md](extensions/README.md)를 참고하세요.
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,12 @@ LLM instructions that are loaded alongside the core schema.
 - `search-chromadb.md` — Semantic search backend (ChromaDB + sentence-transformers)
 - `obsidian.md` — Obsidian vault integration
 - `connected-wikis.md` — Toggle external seojae wikis as extended knowledge sources
-  ([사용 가이드](docs/connected-wikis-guide.ko.md))
+  ([사용 가이드](docs/connected-wikis-guide.ko.md)). Try it right away with the public
+  sample wiki [`Laeyoung/den`](https://github.com/Laeyoung/den):
+  ```bash
+  venv/bin/python tools/connected_wikis.py connect https://github.com/Laeyoung/den --id den --decision consent=accept
+  venv/bin/python tools/search.py --query "espresso extraction" --collections wiki,wiki-ext-den
+  ```
 
 See [extensions/README.md](extensions/README.md) for details on creating your own.
 

--- a/README.md
+++ b/README.md
@@ -107,17 +107,19 @@ See [docs/getting-started.md](docs/getting-started.md) for a detailed walkthroug
 ## CLI Reference
 
 `tools/search.py` is the only component usable without an LLM tool.
-It requires the Python venv to be active.
+Activate the venv first (or prefix commands with `venv/bin/python`):
 
 ```bash
+source venv/bin/activate
+
 # Semantic search
-venv/bin/python tools/search.py --query "attention mechanism" --top 5
+python tools/search.py --query "attention mechanism" --top 5
 
 # Add/update a page in the index
-venv/bin/python tools/search.py --add wiki/concepts/attention-mechanism.md
+python tools/search.py --add wiki/concepts/attention-mechanism.md
 
 # Rebuild the full index
-venv/bin/python tools/search.py --reindex
+python tools/search.py --reindex
 ```
 
 | Argument | Default | Description |
@@ -160,8 +162,9 @@ LLM instructions that are loaded alongside the core schema.
   ([사용 가이드](docs/connected-wikis-guide.ko.md)). Try it right away with the public
   sample wiki [`Laeyoung/den`](https://github.com/Laeyoung/den):
   ```bash
-  venv/bin/python tools/connected_wikis.py connect https://github.com/Laeyoung/den --id den --decision consent=accept
-  venv/bin/python tools/search.py --query "espresso extraction" --collections wiki,wiki-ext-den
+  source venv/bin/activate
+  python tools/connected_wikis.py connect https://github.com/Laeyoung/den --id den --decision consent=accept
+  python tools/search.py --query "espresso extraction" --collections wiki,wiki-ext-den
   ```
 
 See [extensions/README.md](extensions/README.md) for details on creating your own.

--- a/docs/connected-wikis-guide.ko.md
+++ b/docs/connected-wikis-guide.ko.md
@@ -4,6 +4,10 @@
 
 > **3분 요약:** `connect`(신뢰 확인 포함) → `list` → `query` → `toggle` → `pull` → `disconnect`. 외부 wiki는 별도 ChromaDB 컬렉션 `wiki-ext-<id>`에 인덱싱되며 로컬 wiki와 격리됩니다.
 
+> 이 가이드의 명령은 venv가 활성화된 상태(`source venv/bin/activate`)를 가정합니다.
+> 활성화 없이 실행하려면 `python` 대신 `venv/bin/python`을 쓰세요.
+> (LLM 도구가 실행할 때는 항상 `venv/bin/python` full path를 씁니다 — CLAUDE.md 환경 규칙.)
+
 ---
 
 ## 0. 바로 해보기 — 공개 샘플 위키 `Laeyoung/den`
@@ -13,24 +17,26 @@
 main 브랜치를 받고 [환경 설정](../WIKI_SCHEMA.md#setup)만 마쳤다면 그대로 실행해 보세요.
 
 ```bash
+source venv/bin/activate
+
 # 1) 연결 — README 미리보기와 함께 신뢰 확인 프롬프트가 뜹니다 (exit 4)
-venv/bin/python tools/connected_wikis.py connect https://github.com/Laeyoung/den --id den
+python tools/connected_wikis.py connect https://github.com/Laeyoung/den --id den
 # PROMPT: consent | Trust external wiki 'den' content? ...
 # OPTIONS: accept reject
 
 # 2) 내용을 확인했으면 승인과 함께 재호출 — 클론 → 인덱싱 → Connected: den
-venv/bin/python tools/connected_wikis.py connect https://github.com/Laeyoung/den --id den --decision consent=accept
+python tools/connected_wikis.py connect https://github.com/Laeyoung/den --id den --decision consent=accept
 
 # 3) 연결 상태 확인 (pages: 3)
-venv/bin/python tools/connected_wikis.py list
+python tools/connected_wikis.py list
 
 # 4) 내 wiki + den 통합 검색 — den의 커피 페이지가 상위에 나옵니다
-venv/bin/python tools/search.py --query "에스프레소 추출 시간과 분쇄도" --collections wiki,wiki-ext-den
+python tools/search.py --query "에스프레소 추출 시간과 분쇄도" --collections wiki,wiki-ext-den
 # connected-wikis/den/wiki/concepts/espresso-extraction.md [wiki: wiki-ext-den] [score: 0.48]
 # ...
 
 # 5) 실험이 끝나면 정리
-venv/bin/python tools/connected_wikis.py disconnect den
+python tools/connected_wikis.py disconnect den
 ```
 
 첫 실행이라면 임베딩 모델(~470MB) 다운로드로 수 분 걸릴 수 있습니다(§1.2 참고).
@@ -57,14 +63,14 @@ venv/bin/python tools/connected_wikis.py disconnect den
 기본 설치에는 `extensions/search-chromadb.md`가 활성화되어 있어야 합니다. 확인:
 
 ```bash
-venv/bin/python tools/search.py --print-model
+python tools/search.py --print-model
 # backend=search-chromadb
 # model=paraphrase-multilingual-MiniLM-L12-v2
 ```
 
 이 두 줄이 안 나오면 `extensions/` 디렉토리에 `search-chromadb.md`가 있는지 확인하세요.
 
-> **⚠️ 첫 실행 모델 다운로드:** 임베딩 모델(`paraphrase-multilingual-MiniLM-L12-v2`, 약 **470MB**)이 캐시에 없다면 첫 `connect` 또는 `--reindex` 중에 자동으로 다운로드됩니다. 진행 표시 없이 수 분간 멈춘 것처럼 보일 수 있습니다. 미리 캐시하려면 로컬 wiki 인덱스를 먼저 빌드하세요: `venv/bin/python tools/search.py --reindex`.
+> **⚠️ 첫 실행 모델 다운로드:** 임베딩 모델(`paraphrase-multilingual-MiniLM-L12-v2`, 약 **470MB**)이 캐시에 없다면 첫 `connect` 또는 `--reindex` 중에 자동으로 다운로드됩니다. 진행 표시 없이 수 분간 멈춘 것처럼 보일 수 있습니다. 미리 캐시하려면 로컬 wiki 인덱스를 먼저 빌드하세요: `python tools/search.py --reindex`.
 
 ### 1.3 connected-wikis 확장
 
@@ -99,11 +105,11 @@ CLI는 두 가지 방식 중 선택할 수 있습니다.
 
 ```bash
 # 1단계: --decision 없이 호출하면 README 미리보기 + PROMPT 출력 후 exit 4
-venv/bin/python tools/connected_wikis.py connect \
+python tools/connected_wikis.py connect \
   https://github.com/friend/spain-travel-wiki --id spain
 
 # 2단계: 신뢰하기로 결정했다면 같은 명령에 --decision을 붙여 재호출
-venv/bin/python tools/connected_wikis.py connect \
+python tools/connected_wikis.py connect \
   https://github.com/friend/spain-travel-wiki --id spain \
   --decision consent=accept
 ```
@@ -113,7 +119,7 @@ venv/bin/python tools/connected_wikis.py connect \
 **방식 B: 한 번에** — 신뢰가 이미 확인되었다면 처음부터 `--decision` 포함:
 
 ```bash
-venv/bin/python tools/connected_wikis.py connect \
+python tools/connected_wikis.py connect \
   https://github.com/friend/spain-travel-wiki \
   --id spain \
   --decision consent=accept
@@ -146,7 +152,7 @@ Connected: spain
 ## 3. 연결 상태 확인
 
 ```bash
-venv/bin/python tools/connected_wikis.py list
+python tools/connected_wikis.py list
 ```
 
 출력 (실제로 GFM 표 구분 행이 함께 출력됩니다):
@@ -192,7 +198,7 @@ LLM은 자동으로:
 ### 4.2 CLI 직접 사용
 
 ```bash
-venv/bin/python tools/search.py \
+python tools/search.py \
   --query "Madrid restaurants" \
   --top 5 \
   --collections wiki,wiki-ext-spain
@@ -239,13 +245,13 @@ wiki/entities/some-restaurant.md [wiki: wiki] [score: 0.37]
 또는:
 
 ```bash
-venv/bin/python tools/connected_wikis.py toggle spain off
+python tools/connected_wikis.py toggle spain off
 ```
 
 `enabled` 플래그만 false로 바뀝니다. ChromaDB 컬렉션과 클론 디렉토리는 그대로 유지되므로, 다시 켜면 즉시 검색에 포함됩니다 (재인덱싱 불필요).
 
 ```bash
-venv/bin/python tools/connected_wikis.py toggle spain on
+python tools/connected_wikis.py toggle spain on
 ```
 
 ---
@@ -257,7 +263,7 @@ venv/bin/python tools/connected_wikis.py toggle spain on
 > **"연결된 wiki들 업데이트해줘"**
 
 ```bash
-venv/bin/python tools/connected_wikis.py pull
+python tools/connected_wikis.py pull
 ```
 
 내부적으로:
@@ -296,7 +302,7 @@ CLI는 먼저 로컬 wiki에서 해당 id의 인용을 검색해 사용자에게
 **1단계: 인용 검색 (먼저 실행)**
 
 ```bash
-venv/bin/python tools/connected_wikis.py disconnect spain
+python tools/connected_wikis.py disconnect spain
 ```
 
 인용이 없으면 그대로 진행됩니다. 있으면 다음과 같이 출력하고 결정을 요청하며 exit 4로 종료됩니다:
@@ -316,7 +322,7 @@ OPTIONS: proceed abort
 - `abort`: 중단 (먼저 로컬 페이지를 정리하라는 신호)
 
 ```bash
-venv/bin/python tools/connected_wikis.py disconnect spain \
+python tools/connected_wikis.py disconnect spain \
   --decision disconnect-grep=proceed
 ```
 
@@ -355,12 +361,12 @@ git push origin main  # github.com/me/wiki-B
 ```bash
 # A 머신에서 (B의 wiki를 연결)
 cd ~/wiki-A
-venv/bin/python tools/connected_wikis.py connect \
+python tools/connected_wikis.py connect \
   https://github.com/me/wiki-B --id b --decision consent=accept
 
 # B 머신에서 (A의 wiki를 연결)
 cd ~/wiki-B
-venv/bin/python tools/connected_wikis.py connect \
+python tools/connected_wikis.py connect \
   https://github.com/me/wiki-A --id a --decision consent=accept
 ```
 
@@ -372,7 +378,7 @@ venv/bin/python tools/connected_wikis.py connect \
 
 ```bash
 cd ~/wiki-A
-venv/bin/python tools/connected_wikis.py connect \
+python tools/connected_wikis.py connect \
   /Users/me/wiki-B --id b --decision consent=accept
 ```
 

--- a/docs/connected-wikis-guide.ko.md
+++ b/docs/connected-wikis-guide.ko.md
@@ -6,6 +6,38 @@
 
 ---
 
+## 0. 바로 해보기 — 공개 샘플 위키 `Laeyoung/den`
+
+친구의 wiki가 아직 없어도 됩니다. 이 기능의 E2E 검증에 사용된 공개 샘플 위키
+[`Laeyoung/den`](https://github.com/Laeyoung/den)(커피 지식 위키, 페이지 3개)이 준비되어 있습니다.
+main 브랜치를 받고 [환경 설정](../WIKI_SCHEMA.md#setup)만 마쳤다면 그대로 실행해 보세요.
+
+```bash
+# 1) 연결 — README 미리보기와 함께 신뢰 확인 프롬프트가 뜹니다 (exit 4)
+venv/bin/python tools/connected_wikis.py connect https://github.com/Laeyoung/den --id den
+# PROMPT: consent | Trust external wiki 'den' content? ...
+# OPTIONS: accept reject
+
+# 2) 내용을 확인했으면 승인과 함께 재호출 — 클론 → 인덱싱 → Connected: den
+venv/bin/python tools/connected_wikis.py connect https://github.com/Laeyoung/den --id den --decision consent=accept
+
+# 3) 연결 상태 확인 (pages: 3)
+venv/bin/python tools/connected_wikis.py list
+
+# 4) 내 wiki + den 통합 검색 — den의 커피 페이지가 상위에 나옵니다
+venv/bin/python tools/search.py --query "에스프레소 추출 시간과 분쇄도" --collections wiki,wiki-ext-den
+# connected-wikis/den/wiki/concepts/espresso-extraction.md [wiki: wiki-ext-den] [score: 0.48]
+# ...
+
+# 5) 실험이 끝나면 정리
+venv/bin/python tools/connected_wikis.py disconnect den
+```
+
+첫 실행이라면 임베딩 모델(~470MB) 다운로드로 수 분 걸릴 수 있습니다(§1.2 참고).
+아래부터는 이 과정 하나하나가 무엇을 하는지, 실제 상황(친구의 wiki 연결)에 어떻게 쓰는지를 설명합니다.
+
+---
+
 ## 1. 사전 준비
 
 ### 1.1 두 개의 seojae 인스턴스
@@ -16,6 +48,7 @@
 |---|---|---|
 | **Git 원격** | `https://github.com/friend/spain-travel-wiki` | 클론 → 인덱싱. `pull`로 동기화 |
 | **로컬 경로** | `/Users/me/another-wiki` | mtime 기반 동기화. 같은 머신의 다른 seojae 폴더 |
+| **공개 샘플** | `https://github.com/Laeyoung/den` | 바로 테스트용 커피 지식 위키 (§0 참고) |
 
 외부 wiki는 seojae 구조(`wiki/` 디렉토리에 frontmatter 있는 `*.md` 페이지들)를 따라야 합니다.
 

--- a/extensions/connected-wikis.md
+++ b/extensions/connected-wikis.md
@@ -19,6 +19,11 @@ runs `tools/connected_wikis.py init` automatically, which:
 
 Manual init: `venv/bin/python tools/connected_wikis.py init`
 
+**Sample wiki for testing:** a public fixture wiki is available at
+`https://github.com/Laeyoung/den` (coffee-knowledge pages; suggested id: `den`).
+Use it to demo or verify the Connect/Query/Pull/Disconnect workflows end-to-end
+— see the walkthrough in `docs/connected-wikis-guide.ko.md` §0.
+
 ## Workflows
 
 This extension adds six workflows (`Init`, `Connect`, `Toggle`, `Disconnect`,


### PR DESCRIPTION
## Summary

main을 받은 사람이 외부 위키 없이도 connected-wikis를 **바로 테스트**할 수 있도록, E2E 검증에 사용한 공개 샘플 위키 [`Laeyoung/den`](https://github.com/Laeyoung/den)(커피 지식, 3페이지)을 문서에 반영합니다.

- `docs/connected-wikis-guide.ko.md` — §0 "바로 해보기" 추가: connect(신뢰 프롬프트 포함) → list → 통합 query → disconnect 전체 시퀀스 + 예상 출력. §1.1 표에 샘플 행 추가
- `README.md` / `README.ko.md` — connected-wikis 확장 항목에 2줄 퀵스타트 스니펫
- `extensions/connected-wikis.md` — LLM용 확장 문서에 샘플 위키 안내 (자연어 데모/검증에 활용)

### 설계 노트
`connected-wikis.json`을 미리 심는 방식은 **의도적으로 피했습니다** — 커밋된 config는 신뢰 경계라서 첫 pull이 consent 게이트 없이 클론하기 때문입니다. 문서로 안내하면 사용자가 신뢰 확인 흐름을 그대로 경험합니다.

### Verification
문서에 적힌 명령을 scratch 클론에서 그대로 실행해 확인: connect → list(pages 3) → 통합 검색(den 페이지 1위) → disconnect 모두 정상.

🤖 Generated with [Claude Code](https://claude.com/claude-code)