### PR TITLE
chore: open-source launch prep — CI, community health files, changelog

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,41 @@
+name: Bug report
+description: Something isn't working as documented
+labels: [bug]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you expect, and what happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Say "ingest raw/articles/example.md" to the LLM tool
+        2. ...
+    validations:
+      required: true
+  - type: dropdown
+    id: llm-tool
+    attributes:
+      label: LLM coding tool
+      options:
+        - Claude Code
+        - Codex CLI
+        - Gemini CLI
+        - Other / not tool-related
+    validations:
+      required: true
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      placeholder: "3.12.4"
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant output or logs
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Question / Discussion
+    url: https://github.com/VibeVista/seojae/discussions
+    about: Ask questions and share how you use Seojae

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,23 @@
+name: Feature request
+description: Suggest a new workflow, extension, or improvement
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: >
+        If this could be a Seojae extension (a .md file in extensions/),
+        mention that — extensions are the preferred way to add capabilities.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+# Summary
+
+<!-- What does this PR change, and why? -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature / workflow
+- [ ] New or updated extension
+- [ ] Documentation
+- [ ] Other
+
+## Checklist
+
+- [ ] Tests pass: `SKIP_MODEL_TESTS=true venv/bin/python -m pytest tests/`
+- [ ] Documentation updated (README, WIKI_SCHEMA.md, or extension docs) if behavior changed
+- [ ] No personal wiki content included — `main` carries the framework only

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run tests
+        env:
+          # Skip tests that download the ~470MB embedding model
+          SKIP_MODEL_TESTS: "true"
+        run: python -m pytest tests/ -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2026-07-16
+
+Initial public release.
+
+### Added
+
+- **WIKI_SCHEMA.md** — tool-agnostic wiki schema defining the 3-tier
+  architecture (raw sources → wiki → schema) and 5 core workflows:
+  Ingest, Query, Check-New, Lint, Reindex
+- **Multi-tool support** — pre-configured rule files for Claude Code
+  (`CLAUDE.md`), Codex CLI (`AGENTS.md`), and Gemini CLI (`GEMINI.md`)
+- **Extension system** — drop-in `.md` files in `extensions/` with
+  capability ownership (`provides`/`overrides`) and dependency declarations
+- **search-chromadb extension** — semantic search over wiki pages using
+  ChromaDB and sentence-transformers (`tools/search.py`)
+- **obsidian extension** — Obsidian vault integration
+- **connected-wikis extension** — connect external Seojae wikis as
+  read-only extended knowledge sources with consent gating
+  (`tools/connected_wikis.py`)
+- **Example content** — Andrej Karpathy-themed raw sources and generated
+  wiki pages (Software 2.0, Vibe Coding, Intro to LLMs)
+- **Bilingual documentation** — English and Korean README, CONTRIBUTING,
+  and guides
+- **Landing page** (`landing/index.html`)
+- **Test suite** — 130+ tests covering search and connected-wikis tools
+
+[Unreleased]: https://github.com/VibeVista/seojae/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/VibeVista/seojae/releases/tag/v1.0.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at laeyoung@comcom.ai. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.ko.md
+++ b/CONTRIBUTING.ko.md
@@ -3,6 +3,9 @@
 Seojae에 관심을 가져주셔서 감사합니다! 이 가이드는 기여를 시작하는
 방법, 받아들이는 기여 유형, 그리고 따르는 컨벤션을 설명합니다.
 
+이 프로젝트에 참여하는 것은 [행동 강령(Code of Conduct)](CODE_OF_CONDUCT.md)을
+준수하는 것에 동의함을 의미합니다.
+
 ## 기여 방법
 
 **이슈** — 버그 리포트, 기능 요청, 확장(Extension) 아이디어를 환영합니다.
@@ -22,7 +25,7 @@ git 히스토리가 깔끔해집니다.
 
 ```bash
 # 저장소 클론
-git clone https://github.com/Laeyoung/seojae.git
+git clone https://github.com/VibeVista/seojae.git
 cd seojae
 
 # 가상 환경 생성

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,9 @@ Thank you for your interest in contributing to Seojae! This guide covers
 how to get started, what kinds of contributions we accept, and the conventions
 we follow.
 
+By participating in this project, you agree to abide by our
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
 ## How to Contribute
 
 **Issues** — We welcome bug reports, feature requests, and extension ideas.
@@ -23,7 +26,7 @@ faster and keeps the git history readable.
 
 ```bash
 # Clone the repository
-git clone https://github.com/Laeyoung/seojae.git
+git clone https://github.com/VibeVista/seojae.git
 cd seojae
 
 # Create a virtual environment

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,5 +1,11 @@
 # Seojae (서재)
 
+[![CI](https://github.com/VibeVista/seojae/actions/workflows/ci.yml/badge.svg)](https://github.com/VibeVista/seojae/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
+
+[English](README.md) | **한국어**
+
 Seojae (서재)는 LLM 기반 지식 위키 프레임워크입니다. 원본 소스 — 아티클, 논문,
 영상, 노트 — 를 넣으면 LLM 코딩 도구가 자동으로 구조화된 교차 참조 위키를
 만들어줍니다.
@@ -68,7 +74,7 @@ LLM이 위키를 관리할 수 있습니다.
 
 ```bash
 # 1. 리포 클론
-git clone https://github.com/Laeyoung/seojae.git
+git clone https://github.com/VibeVista/seojae.git
 cd seojae
 
 # 2. LLM 도구로 열기 (규칙 파일을 자동으로 읽습니다)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Seojae (서재)
 
+[![CI](https://github.com/VibeVista/seojae/actions/workflows/ci.yml/badge.svg)](https://github.com/VibeVista/seojae/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
+
+**English** | [한국어](README.ko.md)
+
 Seojae is an LLM-powered knowledge wiki framework. Feed it raw sources — articles,
 papers, videos, notes — and your LLM coding tool automatically builds a structured,
 cross-referenced wiki.
@@ -68,7 +74,7 @@ your wiki from the moment you start a session.
 
 ```bash
 # 1. Clone the repo
-git clone https://github.com/Laeyoung/seojae.git
+git clone https://github.com/VibeVista/seojae.git
 cd seojae
 
 # 2. Open with your LLM tool (it auto-reads the rule file)

--- a/RELEASE_GUIDE.md
+++ b/RELEASE_GUIDE.md
@@ -1,302 +1,58 @@
-# Seojae (서재) — 오픈소스 공개 가이드
-
-이 문서는 `go-open-source-project` 브랜치의 내용을 새 GitHub 리포지토리로 공개하는 절차를 안내합니다.
-
----
-
-## 사전 준비
-
-### 필요한 것
-
-- GitHub 계정 (리포 생성 권한)
-- Git CLI 또는 `gh` CLI
-- 현재 `go-open-source-project` 브랜치가 최신 상태인지 확인
-
-### 공개 전 체크리스트
-
-- [ ] 개인 정보 제거 확인 — `git ls-files`로 tracked 파일 목록 검토
-- [ ] `LLM-Wiki` 문자열이 남아있지 않은지 확인: `grep -r "LLM-Wiki" *.md`
-- [ ] 리포 URL이 `seojae`로 통일되어 있는지 확인
-- [ ] LICENSE 파일의 저작자 이름 확인
-
----
-
-## Step 1: GitHub 리포지토리 생성
-
-### 옵션 A: GitHub 웹에서 생성
-
-1. https://github.com/new 접속
-2. Repository name: `seojae`
-3. Description: `LLM-powered knowledge wiki framework — 서재(書齋)`
-4. **Public** 선택
-5. **Initialize this repository with** 항목 모두 체크 해제 (README, .gitignore, license 모두 이미 있음)
-6. **Create repository** 클릭
-
-### 옵션 B: `gh` CLI로 생성
-
-```bash
-gh repo create Laeyoung/seojae --public --description "LLM-powered knowledge wiki framework — 서재(書齋)"
-```
-
----
-
-## Step 2: 파일 복사 및 첫 커밋
-
-`go-open-source-project` 브랜치의 git 히스토리에는 개인 콘텐츠 삭제 이력이 남아 있으므로, **새 리포에 깨끗한 첫 커밋**으로 시작합니다.
-
-```bash
-# 1. 새 디렉토리 생성 및 git 초기화
-mkdir ../seojae
-cd ../seojae
-git init
-
-# 2. 원본 브랜치에서 파일 복사 (.git 제외)
-cp ../LLM-Wiki/.gitignore .
-cp ../LLM-Wiki/WIKI_SCHEMA.md .
-cp ../LLM-Wiki/CLAUDE.md .
-cp ../LLM-Wiki/AGENTS.md .
-cp ../LLM-Wiki/GEMINI.md .
-cp ../LLM-Wiki/README.md .
-cp ../LLM-Wiki/README.ko.md .
-cp ../LLM-Wiki/CONTRIBUTING.md .
-cp ../LLM-Wiki/CONTRIBUTING.ko.md .
-cp ../LLM-Wiki/LICENSE .
-cp ../LLM-Wiki/index.md .
-cp ../LLM-Wiki/log.md .
-cp ../LLM-Wiki/requirements.txt .
-
-# 3. 디렉토리 구조 복사
-cp -r ../LLM-Wiki/extensions .
-cp -r ../LLM-Wiki/tools .
-cp -r ../LLM-Wiki/tests .
-cp -r ../LLM-Wiki/raw .
-cp -r ../LLM-Wiki/wiki .
-cp -r ../LLM-Wiki/docs .
-
-# 4. 첫 커밋
-git add -A
-git commit -m "init: Seojae (서재) — LLM-powered knowledge wiki framework"
-```
-
----
-
-## Step 3: 복사 결과 검증
-
-```bash
-# 파일 수 확인 (36개여야 함)
-git ls-files | wc -l
-
-# 개인 정보 누출 검사
-grep -r "LLM-Wiki" . --include="*.md"         # 결과 없어야 함
-grep -r "user@example.com" . --include="*.md"      # 결과 없어야 함
-grep -r "오늘의집" . --include="*.md"            # 결과 없어야 함
-grep -r ".claude/commands" . --include="*.md"  # 결과 없어야 함
-
-# 파일 구조 확인
-find . -not -path './.git/*' -type f | sort
-```
-
-**예상 파일 목록 (36개):**
-
-```
-.gitignore
-AGENTS.md
-CLAUDE.md
-CONTRIBUTING.ko.md
-CONTRIBUTING.md
-GEMINI.md
-LICENSE
-README.ko.md
-README.md
-WIKI_SCHEMA.md
-docs/getting-started.md
-extensions/README.md
-extensions/obsidian.md
-extensions/search-chromadb.md
-index.md
-log.md
-raw/articles/software-2.0.md
-raw/articles/vibe-coding.md
-raw/assets/.gitkeep
-raw/books/.gitkeep
-raw/misc/.gitkeep
-raw/myself/.gitkeep
-raw/papers/.gitkeep
-raw/videos/intro-to-llms.md
-requirements.txt
-tests/__init__.py
-tests/test_search.py
-tools/__init__.py
-tools/search.py
-wiki/concepts/software-2-0.md
-wiki/concepts/vibe-coding.md
-wiki/entities/andrej-karpathy.md
-wiki/sources/intro-to-llms.md
-wiki/sources/software-2.0.md
-wiki/sources/vibe-coding-karpathy.md
-wiki/synthesis/karpathy-software-evolution.md
-```
-
----
-
-## Step 4: Remote 연결 및 Push
-
-```bash
-# remote 추가
-git remote add origin https://github.com/Laeyoung/seojae.git
-
-# main 브랜치로 push
-git branch -M main
-git push -u origin main
-```
-
----
-
-## Step 5: GitHub 리포 설정
-
-### 5-1. About 섹션
-
-리포 페이지 우측 톱니바퀴(Settings) → About:
-- **Description:** `LLM-powered knowledge wiki framework — 서재(書齋)`
-- **Website:** (선택) 프로젝트 문서 URL
-- **Topics:** `llm`, `knowledge-management`, `wiki`, `claude-code`, `codex`, `gemini-cli`, `obsidian`, `rag`, `personal-wiki`, `seojae`
-
-### 5-2. Social Preview 이미지 (선택)
-
-Settings → Social preview에 1280x640px 이미지 업로드. 프로젝트 이름과 간단한 다이어그램 포함하면 좋음.
-
-### 5-3. GitHub Topics
-
-리포 홈 → About 옆 "Manage topics" 클릭:
-```
-llm  knowledge-management  wiki  personal-wiki  claude-code
-codex  gemini-cli  obsidian  chromadb  seojae
-```
-
----
-
-## Step 6: 동작 확인
-
-새 리포를 클론해서 실제로 동작하는지 확인합니다.
-
-```bash
-# 다른 디렉토리에서 클론
-cd /tmp
-git clone https://github.com/Laeyoung/seojae.git
-cd seojae
-
-# Python 환경 셋업
-python3 -m venv venv
-venv/bin/pip install -r requirements.txt
-
-# 검색 인덱스 구축 (첫 실행: ~470MB 모델 다운로드)
-venv/bin/python tools/search.py --reindex
-
-# 테스트 쿼리
-venv/bin/python tools/search.py --query "vibe coding"
-
-# 테스트 실행
-SKIP_MODEL_TESTS=true venv/bin/python -m pytest tests/test_search.py -v
-```
-
-**예상 결과:**
-- `--reindex`: `Reindex complete: 7 pages indexed, 0 skipped`
-- `--query "vibe coding"`: Karpathy 관련 위키 페이지들이 검색 결과로 나옴
-- `pytest`: 모든 unit 테스트 통과
-
----
-
-## Step 7: 공개 후 안내
-
-### Release 생성 (선택)
-
-```bash
-gh release create v1.0.0 --title "v1.0.0 — Initial Release" --notes "$(cat <<'EOF'
-# Seojae (서재) v1.0.0
-
-LLM-powered knowledge wiki framework의 첫 번째 릴리스입니다.
-
-## Features
-
-- **WIKI_SCHEMA.md** — 도구 중립적 위키 스키마 (Claude Code, Codex, Gemini CLI 지원)
-- **Extension System** — 마크다운 파일 추가/제거로 기능 확장
-- **Semantic Search** — ChromaDB + sentence-transformers 기반 시맨틱 검색
-- **Karpathy 예시** — Software 2.0, Vibe Coding, Intro to LLMs 테마 예시 콘텐츠
-- **이중 언어 문서** — 영어 + 한국어 README, CONTRIBUTING, 튜토리얼
-
-## Getting Started
-
-```bash
-git clone https://github.com/Laeyoung/seojae.git
-cd seojae
-# Open with your LLM coding tool and say: "initialize this wiki"
-```
-
-See [docs/getting-started.md](docs/getting-started.md) for the full tutorial.
-EOF
-)"
-```
-
-### 공유할 곳
-
-- [ ] 개인 블로그 / Velog에 소개 글
-- [ ] Twitter/X에 공유 (Karpathy 예시 언급하면 주목도 높음)
-- [ ] Reddit r/LocalLLaMA, r/ObsidianMD
-- [ ] Hacker News (Show HN)
-- [ ] 한국 개발자 커뮤니티 (GeekNews, Disquiet 등)
-
----
-
-## 문제 해결
-
-### Push가 거부되는 경우
-
-```bash
-# GitHub에서 리포 생성 시 README/LICENSE를 추가했다면:
-git pull origin main --allow-unrelated-histories
-# 충돌 해결 후:
-git push -u origin main
-```
-
-### 파일이 누락된 경우
-
-```bash
-# 원본 브랜치에서 특정 파일 다시 복사
-cp ../LLM-Wiki/<missing-file> .
-git add <missing-file>
-git commit -m "fix: add missing file"
-git push
-```
-
-### 민감 정보가 발견된 경우
-
-```bash
-# 해당 파일 수정 후
-git add <file>
-git commit -m "fix: remove sensitive content"
-git push
-
-# 이미 push한 커밋에서 민감 정보 제거가 필요하면:
-# (주의: force push는 기존 클론에 영향)
-git filter-branch 또는 BFG Repo-Cleaner 사용
-```
-
----
-
-## 요약 플로우차트
-
-```
-1. GitHub 리포 생성 (seojae, public, empty)
-   ↓
-2. 파일 복사 (go-open-source-project 브랜치 → 새 디렉토리)
-   ↓
-3. 검증 (36개 파일, 개인정보 없음)
-   ↓
-4. Push (origin/main)
-   ↓
-5. GitHub 설정 (description, topics, social preview)
-   ↓
-6. 동작 확인 (clone → setup → reindex → query → test)
-   ↓
-7. Release 생성 + 공유
-```
+# Release Guide
+
+Maintainer process for cutting a new Seojae release.
+
+## Versioning
+
+Seojae follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html):
+
+- **Major** — breaking changes to `WIKI_SCHEMA.md` workflows, the extension
+  contract (frontmatter fields, capability model), or CLI interfaces
+- **Minor** — new workflows, extensions, or CLI features that are
+  backward-compatible
+- **Patch** — bug fixes and documentation-only changes
+
+The wiki schema has its own `schema_version` in the YAML block at the top of
+`WIKI_SCHEMA.md`. Bump it when a change affects extension compatibility, and
+mention the bump in the release notes.
+
+## Release checklist
+
+1. **Verify `main` is green**
+   ```bash
+   git checkout main && git pull
+   SKIP_MODEL_TESTS=true venv/bin/python -m pytest tests/ -v
+   ```
+   Also check the [CI status](https://github.com/VibeVista/seojae/actions).
+
+2. **Update CHANGELOG.md** — move entries from `[Unreleased]` into a new
+   version section with today's date, and update the comparison links at
+   the bottom. Commit as `schema: release vX.Y.Z changelog`.
+
+3. **Sync AGENTS.md if the schema changed** — Codex CLI reads an inlined
+   copy of `WIKI_SCHEMA.md`. Verify it is current and under the 32KiB limit:
+   ```bash
+   wc -c AGENTS.md
+   ```
+
+4. **Tag and push**
+   ```bash
+   git tag vX.Y.Z
+   git push origin main --tags
+   ```
+
+5. **Create the GitHub release**
+   ```bash
+   gh release create vX.Y.Z --title "vX.Y.Z" \
+     --notes "See CHANGELOG.md for details."
+   ```
+   Paste the CHANGELOG section for the version into the release notes.
+
+6. **Announce** (optional) — blog, X/Twitter, Reddit (r/LocalLLaMA,
+   r/ObsidianMD), Hacker News, GeekNews.
+
+## Branch policy
+
+- `main` carries the **framework only** — no personal wiki content.
+- Feature work happens on branches and lands via reviewed PRs.
+- Releases are tagged from `main` only.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release (and the `main` branch) receives security updates.
+
+## Reporting a Vulnerability
+
+Please do **not** open a public issue for security vulnerabilities.
+
+Instead, use one of these private channels:
+
+- **GitHub private vulnerability reporting** (preferred):
+  [Report a vulnerability](https://github.com/VibeVista/seojae/security/advisories/new)
+- **Email**: laeyoung@comcom.ai
+
+Include a description of the issue, steps to reproduce, and the potential impact.
+You can expect an initial response within 7 days.
+
+## Scope Notes
+
+Seojae is a framework executed by LLM coding tools (Claude Code, Codex CLI,
+Gemini CLI). Two areas deserve particular care:
+
+- **Prompt injection via ingested sources** — content placed in `raw/` or fetched
+  from connected wikis is processed by an LLM. Malicious instructions embedded in
+  source documents are a known risk class for all LLM-driven tools; reports of
+  injection paths that Seojae's schema or tools could mitigate are welcome.
+- **Connected wikis** (`tools/connected_wikis.py`) — cloning external repositories
+  executes no code by design, but reports of any path traversal, command
+  injection, or consent-bypass issues in the connect/pull flow are high priority.

--- a/docs/devlog/2026-07-16-branch-cleanup-and-pr-review.md
+++ b/docs/devlog/2026-07-16-branch-cleanup-and-pr-review.md
@@ -103,7 +103,7 @@ E2E 픽스처로 만든 `Laeyoung/den`을 **공식 온보딩 샘플로 승격**:
 
 - **`connected-wikis.json`을 미리 심지 않음** — 커밋된 config는 신뢰 경계라 첫 `pull`이 consent 게이트 없이 클론하게 됨. 문서 안내 방식이 사용자가 신뢰 확인 흐름을 그대로 경험하게 한다.
 - **문서 명령 스타일 정리** (사용자 피드백): 사람이 따라 하는 문서(README, 가이드)는 `source venv/bin/activate` 한 번 + `python`으로 통일. **LLM이 실행하는 스펙**(WIKI_SCHEMA 워크플로 기본 커맨드, extensions의 `commands:` 필드)은 `venv/bin/python` full path 유지 — Codex 등에서 venv 활성화가 명령 간 유지되지 않기 때문.
-- **`Laeyoung/den` 재생성**: 초기 커밋이 회사 계정(laeyoung@comcom.ai)으로 작성돼 개인 계정(gadise@gmail.com)으로 히스토리 재작성 + force push. GitHub Contributors 캐시가 남아 repo를 삭제 후 동일 내용으로 재생성함. 커피 지식 3페이지(espresso-extraction, cold-brew, ethiopia-yirgacheffe).
+- **`Laeyoung/den` 재생성**: 초기 커밋이 회사 계정으로 작성돼 개인 계정으로 히스토리 재작성 + force push. GitHub Contributors 캐시가 남아 repo를 삭제 후 동일 내용으로 재생성함. 커피 지식 3페이지(espresso-extraction, cold-brew, ethiopia-yirgacheffe).
 
 ## 리뷰 방법론 메모 (다음에 참고)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,7 +35,7 @@ three have pre-configured rule files in the repo.
 ## 2. Clone and Open
 
 ```bash
-git clone https://github.com/Laeyoung/seojae.git
+git clone https://github.com/VibeVista/seojae.git
 cd seojae
 ```
 

--- a/docs/oss-launch-checklist.md
+++ b/docs/oss-launch-checklist.md
@@ -34,7 +34,7 @@ actions on `main` after this branch is merged.
 
 - [x] Test suite passes locally (`SKIP_MODEL_TESTS=true pytest` — 131 passed)
 - [x] GitHub Actions CI on push/PR (Python 3.9 & 3.12 matrix)
-- [ ] CI green on the launch PR (verify on GitHub after push)
+- [x] CI green on the launch PR (#9: Python 3.9 & 3.12 both pass)
 
 ## Post-merge (maintainer)
 

--- a/docs/oss-launch-checklist.md
+++ b/docs/oss-launch-checklist.md
@@ -1,0 +1,48 @@
+# Open Source Launch Checklist
+
+Status tracker for officially launching Seojae as an open source project.
+Items marked `[x]` are complete; items under "Post-merge (maintainer)" require
+actions on `main` after this branch is merged.
+
+## Repository foundation
+
+- [x] Public GitHub repository (`VibeVista/seojae`)
+- [x] MIT LICENSE with correct copyright holder
+- [x] Repo description and topics set (`llm`, `knowledge-management`, `wiki`, ...)
+- [x] `.gitignore` covers generated artifacts (venv, search-index, session data)
+- [x] No personal/sensitive information in tracked files (swept 2026-07-16)
+
+## Documentation
+
+- [x] README.md / README.ko.md — features, quick start, CLI reference
+- [x] All repo URLs point to `VibeVista/seojae` (was: stale `Laeyoung/seojae`)
+- [x] README badges (CI, license, Python version)
+- [x] Getting-started tutorial (`docs/getting-started.md`)
+- [x] CONTRIBUTING.md / CONTRIBUTING.ko.md
+- [x] CHANGELOG.md (Keep a Changelog format)
+- [x] RELEASE_GUIDE.md rewritten as an ongoing maintainer release process
+  (previous version was a one-time repo-migration guide, now obsolete)
+
+## Community health
+
+- [x] CODE_OF_CONDUCT.md (Contributor Covenant 2.1)
+- [x] SECURITY.md (private vulnerability reporting)
+- [x] Issue templates (bug report, feature request) + config with discussion link
+- [x] Pull request template
+
+## Quality & CI
+
+- [x] Test suite passes locally (`SKIP_MODEL_TESTS=true pytest` — 131 passed)
+- [x] GitHub Actions CI on push/PR (Python 3.9 & 3.12 matrix)
+- [ ] CI green on the launch PR (verify on GitHub after push)
+
+## Post-merge (maintainer)
+
+- [ ] Merge launch PR into `main` (requires user approval per branch policy)
+- [ ] Tag and publish release: `git tag v1.0.0 && git push --tags`, then
+  `gh release create v1.0.0` — see RELEASE_GUIDE.md
+- [ ] (Optional) Enable GitHub Pages for `landing/` (Settings → Pages)
+- [ ] (Optional) Upload a 1280×640 social preview image (Settings → Social preview)
+- [ ] (Optional) Enable GitHub Discussions for community Q&A
+- [ ] Announce: blog, X/Twitter, Reddit (r/LocalLLaMA, r/ObsidianMD),
+  Hacker News (Show HN), GeekNews/Disquiet


### PR DESCRIPTION
# Summary

Prepares Seojae for its official open-source launch. Full status is tracked in [`docs/oss-launch-checklist.md`](docs/oss-launch-checklist.md).

## What's included

- **CI** — GitHub Actions workflow running pytest on Python 3.9 & 3.12 with `SKIP_MODEL_TESTS=true` (no 470MB model download in CI)
- **Community health** — `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1), `SECURITY.md` (private vulnerability reporting + LLM-specific scope notes), bug/feature issue forms, PR template
- **Changelog** — `CHANGELOG.md` in Keep a Changelog format with the v1.0.0 entry
- **RELEASE_GUIDE.md rewrite** — the old file was a one-time repo-migration guide (already executed, referenced the pre-rename `LLM-Wiki` repo); it's now an ongoing maintainer release process (semver policy, release checklist, branch policy)
- **URL fixes** — `git clone` URLs in README/CONTRIBUTING/getting-started still pointed to `Laeyoung/seojae`; now `VibeVista/seojae`
- **README polish** — CI/license/Python badges, EN↔KO cross-links
- **Privacy sweep** — redacted personal emails from a devlog; verified no other personal/sensitive info in tracked files

## Verification

- `SKIP_MODEL_TESTS=true venv/bin/python -m pytest tests/` — **131 passed, 5 skipped**
- CI will run on this PR — first live validation of the workflow (including the Python 3.9 claim from README)

## Post-merge (maintainer actions)

1. Tag `v1.0.0` and create the GitHub release (see new RELEASE_GUIDE.md)
2. Optional: enable GitHub Pages for `landing/`, upload social preview image, enable Discussions

🤖 Generated with [Claude Code](https://claude.com/claude-code)